### PR TITLE
[feat/prettier] Añadido Prettier para el formateo del código del repositorio

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+pnpm-lock.yaml
+package.json

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,12 @@
+{
+  "singleQuote": true,
+  "tabWidth": 2,
+  "useTabs": false,
+  "plugins": ["prettier-plugin-astro"],
+  "overrides": [
+    {
+      "files": "*.astro",
+      "options": { "parser": "astro" }
+    }
+  ]
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,4 +1,4 @@
 {
-  "recommendations": ["astro-build.astro-vscode"],
+  "recommendations": ["astro-build.astro-vscode", "esbenp.prettier-vscode"],
   "unwantedRecommendations": []
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true,
+  "prettier.requireConfig": true
+}

--- a/package.json
+++ b/package.json
@@ -6,9 +6,15 @@
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
   },
   "dependencies": {
     "astro": "^5.5.5"
+  },
+  "devDependencies": {
+    "prettier": "^3.5.3",
+    "prettier-plugin-astro": "^0.14.1"
   }
 }


### PR DESCRIPTION
## Descripción
Se añadió Prettier ya que ayuda a mantener la consistencia y a que todo el código siga los mismos estándares de formato.

## Cambios realizados  
- Añade configuración de Prettier (.prettierrc) para comillas simples y tabs de 2 espacios
- Agrega extensiones recomendadas de VS Code (.vscode/extensions.json)
- Incluye scripts de formateo en package.json (format, format:check)
- Configura VS Code para formatear automáticamente al guardar