### PR TITLE
style(colaboraciones):fix unused background-clip classname

### DIFF
--- a/src/components/ColaboracionesDestacadas.astro
+++ b/src/components/ColaboracionesDestacadas.astro
@@ -9,10 +9,10 @@ const visibleCards = 3;
 <section id="colaboraciones" class="h-auto w-auto bg-gray-950">
   <div class="relative z-30 h-[600px]">
     <div
-      class="second-clip absolute top-0 right-0 h-[600px] w-[8000px] bg-orange-500"
+      class="background-clip-orange second-clip absolute top-0 right-0 h-[600px] w-[8000px] bg-orange-500"
     >
     </div>
-    <div class="general z-30 bg-teal-300">
+    <div class="background-clip-teal general z-30 bg-teal-300">
       <div
         class="flex flex-col items-start justify-between gap-8 pt-32 pr-10 pl-10"
       >


### PR DESCRIPTION
Los classname **.background-clip-orange y .background-clip-teal** no se usaban por lo que se veian rotos los estilos de la seccion de colabs destacadas, ademas tenia una clase **.second-clip** que no existia
<img width="874" height="378" alt="Screenshot 2025-12-27 at 10-25-23 Digital Revolution Web Comunidad de Talentos" src="https://github.com/user-attachments/assets/3c288c6c-39f9-4a20-9350-7ab6bf8fc961" />
